### PR TITLE
Fix import issue to unblock node-fetch update

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "Auto-closes PRs against parts of your codebase",
   "main": "build/index.js",
-  "type": "module",
   "scripts": {
     "check": "gts check",
     "clean": "gts clean",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Auto-closes PRs against parts of your codebase",
   "main": "build/index.js",
+  "type": "module",
   "scripts": {
     "check": "gts check",
     "clean": "gts clean",

--- a/src/process-diff.ts
+++ b/src/process-diff.ts
@@ -1,5 +1,6 @@
 import * as parse from 'parse-diff';
-import fetch, {Headers} from 'node-fetch';
+const fetch = require('node-fetch');
+import {Headers} from 'node-fetch';
 
 export async function processDiffUrl(
   htmlUrl: string,


### PR DESCRIPTION
Trying to upgrade `node-fetch` via dependabot PR results in:
>  SyntaxError: Cannot use import statement outside a module

(https://github.com/aws-github-ops/pr-regex-exclude/runs/6803632774?check_suite_focus=true)

Fix recommendation: https://stackoverflow.com/questions/62488898/node-js-syntaxerror-cannot-use-import-statement-outside-a-module